### PR TITLE
add consumer metrics

### DIFF
--- a/public/server/controllers/consumerController.js
+++ b/public/server/controllers/consumerController.js
@@ -14,19 +14,30 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 const axios_1 = __importDefault(require("axios"));
 const consumerController = {
-    getConsumerTotalTime(req, res, next) {
+    // async consumerTotalTime (req: Request, res: Response, next: NextFunction) {
+    //   try {
+    //     const { port, time, interval } = res.locals;
+    //     const { data: { data: { result } } } = await axios.get(`http://localhost:${port}/api/v1/query_range?query=kafka_network_requestmetrics_totaltimems{request="FetchConsumer"}&start=${time}&end=${new Date().toISOString}&step=${interval}`);
+    //     //kafka_network_requestmetrics_totaltimems{request="FetchConsumer"}&start=${new Date().setDate(date.getDate() - 1).toISOString()}&end=${new Date().toISOString()}&step=${interval.toString()}s
+    //     res.locals.consumerTotalTime = result;
+    //     return next();
+    //   } catch(e) {
+    //     return next(e);
+    //   }
+    // },
+    consumerLag(req, res, next) {
         return __awaiter(this, void 0, void 0, function* () {
             try {
-                const { port } = res.locals;
-                const { data: { data: { result } } } = yield axios_1.default.get(`http://localhost:${port}/api/v1/query_range?query=kafka_network_requestmetrics_totaltimems{request="FetchConsumer"}`);
-                //kafka_network_requestmetrics_totaltimems{request="FetchConsumer"}&start=${new Date().setDate(date.getDate() - 1).toISOString()}&end=${new Date().toISOString()}&step=${interval.toString()}s
-                res.locals.consumerTotalTime = result;
+                const { port, interval } = res.locals;
+                const url = `http://localhost:${port}/api/v1/query_range?query=kafka_server_delayedfetchmetrics_expirespersec_fetchertype_consumer&start=${new Date().toISOString()}&end=${new Date().toISOString()}&step=${interval}s`;
+                console.log('url: ', url);
+                const { data: { data: { result } } } = yield axios_1.default.get(url);
+                res.locals.consumerLag = result;
                 return next();
             }
             catch (e) {
                 return next(e);
             }
-            0;
         });
     }
 };

--- a/public/server/controllers/promPortController.js
+++ b/public/server/controllers/promPortController.js
@@ -14,12 +14,16 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 const axios_1 = __importDefault(require("axios"));
 const electron_store_1 = __importDefault(require("electron-store"));
+//import React from 'react';
 //import consumerController from './consumerController';
 const schema = {
     port: {
         type: 'string',
     },
     nickname: {
+        type: 'string',
+    },
+    time: {
         type: 'string',
     }
 };
@@ -47,14 +51,43 @@ const promPortController = {
         });
     },
     savePortToElectronStore(req, res, next) {
-        const { port, nickname } = req.body;
+        const { port, nickname, time } = req.body;
         db.set('port', port);
         db.set('nickname', nickname);
+        db.set('time', time);
         return next();
     },
     getSavedPortFromElectronStore(req, res, next) {
         const port = db.get('port');
         res.locals.port = port;
+        return next();
+    },
+    getSavedStartTimeFromElectronStore(req, res, next) {
+        const time = db.get('time');
+        res.locals.time = time;
+        return next();
+    },
+    getSavedIntervalFromElectronStore(req, res, next) {
+        res.locals.interval = 60;
+        const endTime = res.locals.time;
+        console.log(`endTime: ${endTime}`);
+        // let startTime = new Date();
+        // console.log(`startTime: ${startTime}`);
+        let difference = new Date().getTime() - new Date(endTime).getTime();
+        console.log('DIFFERENCE', difference);
+        if (difference < 60000) {
+            res.locals.interval = 1;
+        }
+        if (difference > 60000 && difference < 300000) {
+            res.locals.interval = 60;
+        }
+        if (difference > 360000 && difference < 7200000) {
+            res.locals.interval = 300;
+        }
+        if (difference > 14400000) {
+            res.locals.interval = 1800;
+        }
+        //return res.locals.interval;
         return next();
     }
 };

--- a/public/server/routers/consumerRouter.js
+++ b/public/server/routers/consumerRouter.js
@@ -4,9 +4,13 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const express_1 = require("express");
+const promPortController_1 = __importDefault(require("../controllers/promPortController"));
 const consumerController_1 = __importDefault(require("../controllers/consumerController"));
 const router = (0, express_1.Router)();
-router.get('/consumer', consumerController_1.default.getConsumerTotalTime, (req, res) => {
-    return res.status(200).json(res.locals.consumerTotalTime);
+router.get('/consumer-lag', promPortController_1.default.getSavedPortFromElectronStore, promPortController_1.default.getSavedStartTimeFromElectronStore, promPortController_1.default.getSavedIntervalFromElectronStore, consumerController_1.default.consumerLag, (req, res) => {
+    return res.status(200).json(res.locals.consumerLag);
 });
+// router.get('/consumer-total-time', promPortController.getSavedPortFromElectronStore, promPortController.getSavedStartTimeFromElectronStore, promPortController.getSavedIntervalFromElectronStore, consumerController.consumerTotalTime, (req: Request, res: Response) => {
+//   return res.status(200).json(res.locals.consumerTotalTime);
+// });
 exports.default = router;

--- a/public/server/server.js
+++ b/public/server/server.js
@@ -8,6 +8,7 @@ const producerRouter_1 = __importDefault(require("./routers/producerRouter"));
 const topicsRouter_1 = __importDefault(require("./routers/topicsRouter"));
 const promPortRouter_1 = __importDefault(require("./routers/promPortRouter"));
 const consumerRouter_1 = __importDefault(require("./routers/consumerRouter"));
+const zookeeperRouter_1 = __importDefault(require("./routers/zookeeperRouter"));
 // import { partitionController } from './controllers/partitionController';
 // import { producerController } from './controllers/producerController';
 // import { promPortController } from './controllers/promPortController';
@@ -34,9 +35,10 @@ app.use('/api/consumer', consumerRouter_1.default);
 app.use('/api/partition', partitionRouter_1.default);
 app.use('/api/producer', producerRouter_1.default);
 app.use('/api/topic', topicsRouter_1.default);
-//app.use((req, res) => res.sendStatus(404));
+app.use('/api/zookeeper', zookeeperRouter_1.default);
+app.use((req, res) => res.sendStatus(404));
 //global error handler
-app.use('/', (err, req, res, next) => {
+app.use((err, req, res, next) => {
     const defaultError = {
         log: 'Express error handler caught unknown middleware error',
         status: 400,

--- a/public/src/components/App.js
+++ b/public/src/components/App.js
@@ -5,10 +5,13 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 const react_1 = __importDefault(require("react"));
 const react_router_dom_1 = require("react-router-dom");
+const react_query_1 = require("react-query");
 const Dashboard_1 = __importDefault(require("./Dashboard"));
 const Home_1 = __importDefault(require("./Home"));
+require("./style.scss");
+const queryClient = new react_query_1.QueryClient();
 function App() {
-    return (react_1.default.createElement("div", null,
+    return (react_1.default.createElement(react_query_1.QueryClientProvider, { client: queryClient },
         react_1.default.createElement(react_router_dom_1.BrowserRouter, null,
             react_1.default.createElement(react_router_dom_1.Routes, null,
                 react_1.default.createElement(react_router_dom_1.Route, { path: "/", element: react_1.default.createElement(Home_1.default, null) }),

--- a/public/src/components/GeneralMetric.js
+++ b/public/src/components/GeneralMetric.js
@@ -4,13 +4,47 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const react_1 = __importDefault(require("react"));
-const SpecificMetric_1 = __importDefault(require("./SpecificMetric"));
-const metricNames = ['Partition', 'Producer', 'Topic', 'Consumer', 'In/Out'];
+const axios_1 = __importDefault(require("axios"));
+const react_query_1 = require("react-query");
+const PartitionData_1 = __importDefault(require("../chart_components/PartitionData"));
+const InOutData_1 = __importDefault(require("../chart_components/InOutData"));
+const ProducerData_1 = __importDefault(require("../chart_components/ProducerData"));
+const TopicData_1 = __importDefault(require("../chart_components/TopicData"));
+const ZookeeperData_1 = __importDefault(require("../chart_components/ZookeeperData"));
+const ConsumerData_1 = __importDefault(require("../chart_components/ConsumerData"));
+const axiosClient = axios_1.default.create({
+    baseURL: 'http://localhost:8080/api/',
+});
 const GeneralMetric = () => {
-    return (react_1.default.createElement("div", null, metricNames.map((name) => (react_1.default.createElement(react_1.default.Fragment, { key: name },
-        react_1.default.createElement("h4", null,
-            name,
-            " metrics: "),
-        react_1.default.createElement(SpecificMetric_1.default, { metricName: name }))))));
+    const endpoints = [
+        '/partition/total-count',
+        '/partition/offline-count',
+        '/producer/total-request-count',
+        '/producer/total-failed-count',
+        '/topic/total-count',
+        '/topic/metrics',
+        '/consumer/consumer-lag',
+        //'/consumer/consumer-total-time',
+        '/zookeeper/avg-latency',
+        // add endpoint here and destructure result from the invocation of "useQueries" function below
+    ];
+    const queries = endpoints.map(endpoint => ({
+        queryKey: endpoint,
+        queryFn: () => axiosClient.get(endpoint).then(res => res.data),
+        refetchInterval: 1000,
+        refetchIntervalInBackground: true,
+    }));
+    const [partitionTotalCount, partitionOfflineCount, producerTotalReqCount, producerTotalFailCount, topicTotalCount, topicMetrics, consumerLag, 
+    //consumerTotalTime,
+    avgLatency,
+    // destructure result here
+    ] = (0, react_query_1.useQueries)(queries);
+    return (react_1.default.createElement(react_1.default.Fragment, null,
+        react_1.default.createElement(PartitionData_1.default, { partitionTotalCount: partitionTotalCount, partitionOfflineCount: partitionOfflineCount }),
+        react_1.default.createElement(ProducerData_1.default, { producerTotalReqCount: producerTotalReqCount, producerTotalFailCount: producerTotalFailCount }),
+        react_1.default.createElement(TopicData_1.default, { topicTotalCount: topicTotalCount }),
+        react_1.default.createElement(InOutData_1.default, { topicMetrics: topicMetrics }),
+        react_1.default.createElement(ConsumerData_1.default, { consumerLag: consumerLag }),
+        react_1.default.createElement(ZookeeperData_1.default, { avgLatency: avgLatency })));
 };
 exports.default = GeneralMetric;

--- a/public/src/components/Home.js
+++ b/public/src/components/Home.js
@@ -32,11 +32,12 @@ const axios_1 = __importDefault(require("axios"));
 const Home = () => {
     const [input, setInput] = (0, react_1.useState)({
         port: null,
-        nickname: null
+        nickname: null,
+        time: null,
     });
     const navigate = (0, react_router_dom_1.useNavigate)();
     const handleOnChange = (e) => {
-        setInput(Object.assign(Object.assign({}, input), { [e.target.name]: e.target.value }));
+        setInput(Object.assign(Object.assign({}, input), { [e.currentTarget.name]: e.currentTarget.value }));
         //console.log(state);
     };
     const handleSubmit = (e) => {
@@ -46,6 +47,7 @@ const Home = () => {
             .post('http://localhost:8080/api/prom-port', {
             port: input.port,
             nickname: input.nickname,
+            time: new Date().toISOString(),
         })
             .then((res) => {
             console.log(res);
@@ -55,32 +57,6 @@ const Home = () => {
             console.log(err);
         });
     };
-    // const Home = () => {
-    //   const navigate = useNavigate();
-    //   const [state, setState] = useState({
-    //     port: '',
-    //     shellName: '',
-    //   });
-    //   const handleOnChange = (e:any) => {
-    //     setState({ ...state, [e.target.name]: e.target.value });
-    //     //console.log(state);
-    //   };
-    //   const handleSubmit = (e:any) => {
-    //     //console.log('You clicked handleSubmit!')
-    //     e.preventDefault();
-    //     axios
-    //       .post('http://localhost:8080/api/prom-port', {
-    //         port: state.port,
-    //         shellName: state.shellName,
-    //       })
-    //       .then((res) => {
-    //         console.log(res);
-    //         navigate('/dashboard');
-    //       })
-    //       .catch((err) => {
-    //         console.log(err);
-    //       });
-    //   };
     return (react_1.default.createElement("div", { className: "home-page" },
         react_1.default.createElement("h1", null, "Kafka Monitor: Your Metrics in a Nutshell"),
         react_1.default.createElement("h2", null, "Enter your Prometheus port and a name for your new metrics shell to get started!"),
@@ -90,7 +66,7 @@ const Home = () => {
                 react_1.default.createElement("input", { className: "form-control user-input", type: "text", name: "port", onChange: handleOnChange, required: true })),
             react_1.default.createElement("label", null,
                 react_1.default.createElement("br", null),
-                "Shell Name:",
+                "Nickname:",
                 react_1.default.createElement("input", { className: "form-control user-input", type: "text", name: "nickname", onChange: handleOnChange, required: true })),
             react_1.default.createElement("br", null),
             react_1.default.createElement("br", null),

--- a/public/types.js
+++ b/public/types.js
@@ -7,4 +7,3 @@ Object.defineProperty(exports, "__esModule", { value: true });
 ;
 ;
 ;
-;

--- a/server/controllers/consumerController.ts
+++ b/server/controllers/consumerController.ts
@@ -3,18 +3,30 @@ import axios from 'axios';
 
 const consumerController = {
 
-  async getConsumerTotalTime (req: Request, res: Response, next: NextFunction) {
+  // async consumerTotalTime (req: Request, res: Response, next: NextFunction) {
+  //   try {
+  //     const { port, time, interval } = res.locals;
+  //     const { data: { data: { result } } } = await axios.get(`http://localhost:${port}/api/v1/query_range?query=kafka_network_requestmetrics_totaltimems{request="FetchConsumer"}&start=${time}&end=${new Date().toISOString}&step=${interval}`);
+  //     //kafka_network_requestmetrics_totaltimems{request="FetchConsumer"}&start=${new Date().setDate(date.getDate() - 1).toISOString()}&end=${new Date().toISOString()}&step=${interval.toString()}s
+  //     res.locals.consumerTotalTime = result;
+  //     return next();
+  //   } catch(e) {
+  //     return next(e);
+  //   }
+  
+  // },
+
+  async consumerLag (req: Request, res: Response, next: NextFunction) {
     try {
-      const { port } = res.locals;
-      const { data: { data: { result } } } = await axios.get(`http://localhost:${port}/api/v1/query_range?query=kafka_network_requestmetrics_totaltimems{request="FetchConsumer"}`);
-      //kafka_network_requestmetrics_totaltimems{request="FetchConsumer"}&start=${new Date().setDate(date.getDate() - 1).toISOString()}&end=${new Date().toISOString()}&step=${interval.toString()}s
-      res.locals.consumerTotalTime = result;
+      const { port, interval } = res.locals;
+      const url = `http://localhost:${port}/api/v1/query_range?query=kafka_server_delayedfetchmetrics_expirespersec_fetchertype_consumer&start=${new Date().toISOString()}&end=${new Date().toISOString()}&step=${interval}s`;
+      console.log('url: ', url)
+      const { data: { data: { result } } } = await axios.get(url)
+      res.locals.consumerLag = result;
       return next();
     } catch(e) {
-      return next(e);
+      return next(e)
     }
-0
-  
   }
 };
 

--- a/server/controllers/promPortController.ts
+++ b/server/controllers/promPortController.ts
@@ -1,7 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 import axios from 'axios';
 import ElectronStore from 'electron-store';
-import React from 'react';
+//import React from 'react';
 //import consumerController from './consumerController';
 
 const schema:any = {
@@ -9,6 +9,9 @@ const schema:any = {
     type: 'string',
   },
   nickname: {
+    type: 'string',
+  },
+  time: {
     type: 'string',
   }
 }
@@ -34,15 +37,53 @@ const promPortController = {
     }
   },
   savePortToElectronStore(req: Request, res: Response, next: NextFunction) {
-    const { port, nickname } = req.body;
+    const { port, nickname, time } = req.body;
     db.set('port', port);
     db.set('nickname', nickname);
+    db.set('time', time);
     return next();
   },
   
   getSavedPortFromElectronStore(req: Request, res: Response, next: NextFunction) {
     const port = db.get('port');
     res.locals.port = port;
+    return next();
+  },
+
+  getSavedStartTimeFromElectronStore(req: Request, res: Response, next: NextFunction) {
+    const time = db.get('time');
+    res.locals.time = time;
+    return next();
+  },
+
+  getSavedIntervalFromElectronStore(req: Request, res: Response, next: NextFunction) {
+
+    res.locals.interval = 60;
+    const endTime = res.locals.time;
+    console.log(`endTime: ${endTime}`);
+    // let startTime = new Date();
+    // console.log(`startTime: ${startTime}`);
+    let difference = new Date().getTime() - new Date(endTime).getTime();
+    console.log('DIFFERENCE', difference);
+    
+    if (difference < 60000) {
+      res.locals.interval = 1;
+    }
+  
+    if (difference > 60000 && difference < 300000) {
+      res.locals.interval = 60;
+    }
+  
+    if (difference > 360000 && difference < 7200000) {
+      res.locals.interval = 300;
+    }
+  
+    if (difference > 14400000) {
+      res.locals.interval = 1800;
+    }
+  
+    //return res.locals.interval;
+
     return next();
   }
 }

--- a/server/controllers/zookeeperController.ts
+++ b/server/controllers/zookeeperController.ts
@@ -2,6 +2,7 @@ import { Request, Response, NextFunction } from 'express';
 import axios from 'axios';
 
 const zookeeperController = {
+  //this data does not change so it's not best for graphs
   async avg_latency (req: Request, res: Response, next: NextFunction) {
     try {
       const { port } = res.locals;

--- a/server/controllers/zookeeperController.ts
+++ b/server/controllers/zookeeperController.ts
@@ -1,0 +1,66 @@
+import { Request, Response, NextFunction } from 'express';
+import axios from 'axios';
+
+const zookeeperController = {
+  async avg_latency (req: Request, res: Response, next: NextFunction) {
+    try {
+      const { port } = res.locals;
+      const { data: { data: { result } } } = await axios.get(`http://localhost:${port}/api/v1/query?query=kafka_server_zookeeperclientmetrics_zookeeperrequestlatencyms`);
+      res.locals.avg_latency = result; //also contains producer requests for EACH topic
+      //console.log(`AVG_LATENCY ${res.locals.avg_latency}`)
+      return next();
+    } catch (e) {
+      return next(e);
+    }
+  }
+
+  // async totalTopicMetrics(req: Request, res: Response, next: NextFunction) {
+  //   try {
+  //     const { port } = res.locals;
+  //     const topicMetrics = [
+  //       axios.get(`http://localhost:${port}/api/v1/query?query=kafka_server_brokertopicmetrics_bytesin_total`), //total bytes in for cluster AND each topic //example: https://i.imgur.com/mHTXzoP.png
+  //       axios.get(`http://localhost:${port}/api/v1/query?query=kafka_server_brokertopicmetrics_bytesout_total`), //total bytes out for cluster AND each topix //example: https://i.imgur.com/zIuiXU2.png
+  //       axios.get(`http://localhost:${port}/api/v1/query?query=kafka_server_brokertopicmetrics_bytesrejected_total`), //example: https://i.imgur.com/RH40ocK.png
+  //       // axios.get(`http://localhost:${port}/api/v1/query?query=`), // put another relevant query here
+  //     ];
+  //     const axiosGetAll = await Promise.all(topicMetrics);
+  //     const destructureResults = axiosGetAll.map(promResult => promResult.data.data.result);
+  //     res.locals.totalTopicMetrics = destructureResults; // this should be an array of arrays
+  //     return next();
+  //   } catch (e) {
+  //     return next(e);
+  //   }
+  // }
+
+};
+
+// topicsController.totalTopicCount = async (req, res, next) => {
+//   try {
+//     const { port } = res.locals;
+//     const { data: { data: { result } } } = await axios.get(`http://localhost:${port}/api/v1/query?query=kafka_controller_kafkacontroller_globaltopiccount`);
+//     res.locals.totalTopicCount = result; //also contains producer requests for EACH topic
+//     return next();
+//   } catch (e) {
+//     return next(e);
+//   }
+// }
+
+// topicsController.totalTopicMetrics = async (req, res, next) => {
+//   try {
+//     const { port } = res.locals;
+//     const topicMetrics = [
+//       axios.get(`http://localhost:${port}/api/v1/query?query=kafka_server_brokertopicmetrics_bytesin_total`), //total bytes in for cluster AND each topic //example: https://i.imgur.com/mHTXzoP.png
+//       axios.get(`http://localhost:${port}/api/v1/query?query=kafka_server_brokertopicmetrics_bytesout_total`), //total bytes out for cluster AND each topix //example: https://i.imgur.com/zIuiXU2.png
+//       axios.get(`http://localhost:${port}/api/v1/query?query=kafka_server_brokertopicmetrics_bytesrejected_total`), //example: https://i.imgur.com/RH40ocK.png
+//       // axios.get(`http://localhost:${port}/api/v1/query?query=`), // put another relevant query here
+//     ];
+//     const axiosGetAll = await Promise.all(topicMetrics);
+//     const destructureResults = axiosGetAll.map(promResult => promResult.data.data.result);
+//     res.locals.totalTopicMetrics = destructureResults; // this should be an array of arrays
+//     return next();
+//   } catch (e) {
+//     return next(e);
+//   }
+// }
+
+export default  zookeeperController;

--- a/server/routers/consumerRouter.ts
+++ b/server/routers/consumerRouter.ts
@@ -1,10 +1,15 @@
 import { Router, Request, Response } from 'express';
+import promPortController from '../controllers/promPortController';
 import consumerController from '../controllers/consumerController'; 
 
 const router: Router = Router();
 
-router.get('/consumer', consumerController.getConsumerTotalTime, (req: Request, res: Response) => {
-  return res.status(200).json(res.locals.consumerTotalTime);
+router.get('/consumer-lag', promPortController.getSavedPortFromElectronStore, promPortController.getSavedStartTimeFromElectronStore, promPortController.getSavedIntervalFromElectronStore, consumerController.consumerLag, (req: Request, res: Response) => {
+  return res.status(200).json(res.locals.consumerLag);
 });
+
+// router.get('/consumer-total-time', promPortController.getSavedPortFromElectronStore, promPortController.getSavedStartTimeFromElectronStore, promPortController.getSavedIntervalFromElectronStore, consumerController.consumerTotalTime, (req: Request, res: Response) => {
+//   return res.status(200).json(res.locals.consumerTotalTime);
+// });
 
 export default router;

--- a/server/routers/zookeeperRouter.ts
+++ b/server/routers/zookeeperRouter.ts
@@ -1,0 +1,12 @@
+import { Router, Request, Response } from 'express';
+import zookeeperController from '../controllers/zookeeperController';
+import promPortController from '../controllers/promPortController';
+
+const router: Router = Router();
+
+router.get('/avg-latency', promPortController.getSavedPortFromElectronStore, zookeeperController.avg_latency, (req: Request, res: Response) => {
+  return res.status(200).json(res.locals.avg_latency);
+});
+
+
+export default router;

--- a/server/server.ts
+++ b/server/server.ts
@@ -3,6 +3,7 @@ import producerRouter from './routers/producerRouter';
 import topicRouter from './routers/topicsRouter';
 import promPortRouter from './routers/promPortRouter';
 import consumerRouter from './routers/consumerRouter';
+import zookeeperRouter from './routers/zookeeperRouter';
 // import { partitionController } from './controllers/partitionController';
 // import { producerController } from './controllers/producerController';
 // import { promPortController } from './controllers/promPortController';
@@ -36,12 +37,13 @@ app.use('/api/consumer', consumerRouter);
 app.use('/api/partition', partitionRouter);
 app.use('/api/producer', producerRouter);
 app.use('/api/topic', topicRouter);
+app.use('/api/zookeeper', zookeeperRouter);
 
 
-//app.use((req, res) => res.sendStatus(404));
+app.use((req, res) => res.sendStatus(404));
 
 //global error handler
-app.use('/', (err: ServerError, req: Request, res: Response, next: NextFunction) => {
+app.use((err: ServerError, req: Request, res: Response, next: NextFunction) => {
   const defaultError = {
     log: 'Express error handler caught unknown middleware error',
     status: 400,

--- a/src/chart_components/ConsumerData.tsx
+++ b/src/chart_components/ConsumerData.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+
+export default function ConsumerData({ consumerLag }): JSX.Element {
+
+  const dataObj = consumerLag.data;
+  let consumerLagMetric;
+
+  for (let prop in dataObj) {
+    if (dataObj.hasOwnProperty(prop)) {
+      //let lastIdx = data
+      consumerLagMetric = dataObj[prop].values[0][1];
+    }
+  }
+
+  
+  return (
+    consumerLag.isLoading ? 
+    <>Loading</> : 
+    <ul>
+      <li>Consumer Lag: {consumerLagMetric} </li>
+      {/* <li><RealTimeChart metrics={metrics} /></li> */}
+      {/* <li>Consumer Total Time: {consumerTotalTime.data[0].value[1]} </li> */}
+      {/* <li><RealTimeChart metrics={metrics} /></li> */}
+    </ul>
+  );
+}

--- a/src/chart_components/ZookeeperData.tsx
+++ b/src/chart_components/ZookeeperData.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+
+export default function ZookeeperData({ avgLatency }): JSX.Element {
+  return (
+    avgLatency.isLoading ? 
+    <>Loading</> : 
+    <ul>
+      <li>Zookeeper Average Latency: {avgLatency.data[0].value[1]} ms</li>
+      {/* <li><RealTimeChart metrics={metrics} /></li> */}
+    </ul>
+  );
+}

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
-import { QueryClient, QueryClientProvider } from 'react-query'
+import { QueryClient, QueryClientProvider } from 'react-query';
 import Dashboard from './Dashboard';
 import Home from './Home';
 import './style.scss'

--- a/src/components/GeneralMetric.tsx
+++ b/src/components/GeneralMetric.tsx
@@ -5,6 +5,8 @@ import PartitionData from '../chart_components/PartitionData';
 import InOutData from '../chart_components/InOutData';
 import ProducerData from '../chart_components/ProducerData';
 import TopicData from '../chart_components/TopicData';
+import ZookeeperData from '../chart_components/ZookeeperData';
+import ConsumerData from '../chart_components/ConsumerData';
 import { Queries } from '../../types'
 
 const axiosClient = axios.create({
@@ -19,13 +21,16 @@ const GeneralMetric = () => {
     '/producer/total-failed-count',
     '/topic/total-count',
     '/topic/metrics',
+    '/consumer/consumer-lag',
+    //'/consumer/consumer-total-time',
+    '/zookeeper/avg-latency',
     // add endpoint here and destructure result from the invocation of "useQueries" function below
   ]
 
   const queries: Queries[] = endpoints.map(endpoint => ({
     queryKey: endpoint,
     queryFn: () => axiosClient.get(endpoint).then(res => res.data),
-    refetchInterval: 2000,
+    refetchInterval: 1000,
     refetchIntervalInBackground: true,
   }))
 
@@ -36,6 +41,9 @@ const GeneralMetric = () => {
     producerTotalFailCount,
     topicTotalCount,
     topicMetrics,
+    consumerLag,
+    //consumerTotalTime,
+    avgLatency,
     // destructure result here
   ] = useQueries(queries)
 
@@ -46,6 +54,8 @@ const GeneralMetric = () => {
       <ProducerData producerTotalReqCount={producerTotalReqCount} producerTotalFailCount={producerTotalFailCount}/>
       <TopicData topicTotalCount={topicTotalCount}/>
       <InOutData topicMetrics={topicMetrics}/>
+      <ConsumerData consumerLag={consumerLag} />
+      <ZookeeperData avgLatency={avgLatency} />
     </>
   )
 };

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -1,13 +1,12 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
-import { Port, Nickname } from '../../types';
-//import { StringDecoder } from 'string_decoder';
+import { Port, Nickname, Time } from '../../types';
 
 interface HomeState {
   port: Port,
   nickname: Nickname,
-  //setState: React.Dispatch<React.SetStateAction<State>>;
+  time: Time,
 }
 
 
@@ -15,7 +14,8 @@ const Home: React.FC = () => {
 
   const [ input, setInput ] = useState<HomeState>({
     port: null,
-    nickname: null
+    nickname: null,
+    time: null,
   })
 
   const navigate = useNavigate();
@@ -33,6 +33,7 @@ const Home: React.FC = () => {
       .post('http://localhost:8080/api/prom-port', {
         port: input.port,
         nickname: input.nickname,
+        time: new Date().toISOString(),
       })
       .then((res) => {
         console.log(res);

--- a/types.ts
+++ b/types.ts
@@ -12,9 +12,10 @@ export type Port = number;
 
 export type Nickname = string;
 
-export interface State {
-  port: Port; 
-  nickname?: Nickname;
+export type Time = string;
+
+export interface timeState {
+  time: Time;
 };
 
 export type EventHandlers = {
@@ -22,12 +23,12 @@ export type EventHandlers = {
   onClick: (e: React.ChangeEventHandler<HTMLInputElement>) => void
 }
 
-export interface QueryProps extends State {
-  query: string;
-  port: Port; 
-  nickname: Nickname;
-  handleOnClick(query: string, port: Port): void;
-};
+// export interface QueryProps extends State {
+//   query: string;
+//   port: Port; 
+//   nickname: Nickname;
+//   handleOnClick(query: string, port: Port): void;
+// };
 
 
 export interface ProducerController {
@@ -48,6 +49,7 @@ export interface PromPortController {
   isPromPortUp: RequestHandler;
   savePortToElectronStore: RequestHandler;
   getSavedPortFromElectronStore: RequestHandler;
+  getSavedStartTimeFromElectronStore: RequestHandler;
 };
 
 export interface PartitionController {


### PR DESCRIPTION
summary of edits:

- updated/added consumerController, consumerRouter, consumerData to display consumer lag. 
- updated/added zookeeperController, zookeeperRouter, zookeeperData to display zookeeper metric
- changed the query to be sent every second instead of 2 seconds to accommodate consumer lag metrics, which expires every second.